### PR TITLE
clean: use a binary distro of gotopt2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: "bazel build //..."
+      - name: Quick check
+        run: "bazel run //build:docker_run -- --help"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,8 +30,20 @@ gazelle_dependencies()
 load("//build:repositories.bzl", "bazel_bid_repositories")
 bazel_bid_repositories()
 
-load("@gotopt2//build:deps.bzl", "gotopt2_dependencies")
-gotopt2_dependencies()
+http_archive(
+    name = "gotopt2",
+    sha256 = "",
+    urls = [
+        "https://github.com/filmil/gotopt2/releases/download/v1.3.1/gotopt2-linux-amd64.zip",
+    ],
+    strip_prefix = "gotopt2",
+    build_file_content = """package(default_visibility = ["//visibility:public"])
+filegroup(
+    name = "bin",
+    srcs = [ "gotopt2", ],
+)
+"""
+)
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -7,8 +7,11 @@ sh_binary(
   name = "docker_run",
   srcs = ["docker_run.sh"],
   visibility = ["//visibility:public"],
+  args = [
+    "$(location @gotopt2//:bin)",
+  ],
   data = [
-    "@gotopt2//cmd/gotopt2:gotopt2",
+    "@gotopt2//:bin",
     "@bazel_tools//tools/bash/runfiles",
   ],
 )

--- a/build/docker_run.sh
+++ b/build/docker_run.sh
@@ -13,36 +13,8 @@
 #                    --container=some-container:tag \
 #                        command arg1 arg2 arg3
 
-# This magic was copied from runfiles by consulting:
-#   https://stackoverflow.com/questions/53472993/how-do-i-make-a-bazel-sh-binary-target-depend-on-other-binary-targets
-
-# --- begin runfiles.bash initialization ---
-# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
-set -eo pipefail
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  if [[ -f "$0.runfiles_manifest" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-    export RUNFILES_DIR="$0.runfiles"
-  fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
-
-# This is seriously weird: should I be guessing the OS and architecture to get
-# at a binary that I want to use?
-readonly _gotopt_binary="$(rlocation \
-  gotopt2/cmd/gotopt2/gotopt2_/gotopt2)"
+readonly _gotopt_binary="${1}"
+shift
 
 # Exit quickly if the binary isn't found. This may happen if the binary location
 # moves internally in bazel.
@@ -88,7 +60,7 @@ EOF
 )
 if [[ "$?" == "11" ]]; then
   # When --help option is used, gotopt2 exits with code 11.
-  exit 1
+  exit 0
 fi
 
 # Evaluate the output of the call to gotopt2, shell vars assignment is here.

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -28,10 +28,3 @@ def bazel_bid_repositories():
         sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
     )
 
-    maybe(
-        git_repository,
-        name = "gotopt2",
-        remote = "https://github.com/filmil/gotopt2",
-        commit = "21c007a22bc51ec580510e5bed4f997f84362e0b",
-    )
-


### PR DESCRIPTION
This removes the need to lug the gotopt2 deps everywhere.