### PR TITLE
clean: mark version 0.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "bazel_rules_bid",
-    version = "0.2.0",
+    version = "0.2.1",
 )
 
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -5,13 +5,24 @@
 
 sh_binary(
   name = "docker_run",
-  srcs = ["docker_run.sh"],
+  srcs = [":gen_docker_run"],
   visibility = ["//visibility:public"],
-  args = [
-    "$(location @gotopt2//:bin)",
-  ],
   data = [
     "@gotopt2//:bin",
     "@bazel_tools//tools/bash/runfiles",
   ],
+)
+
+genrule(
+  name = "gen_docker_run",
+  srcs = [ "docker_run.sh.tpl" ],
+  outs = [ "docker_run.sh" ],
+  cmd = """
+    sed --expression='s|::GOTOPT2_BINARY::|$(location @gotopt2//:bin)|g' \
+        > "$(@)" \
+        < "$(location docker_run.sh.tpl)"
+  """,
+  tools = [
+    "@gotopt2//:bin",
+  ]
 )

--- a/build/docker_run.sh
+++ b/build/docker_run.sh
@@ -13,7 +13,7 @@
 #                    --container=some-container:tag \
 #                        command arg1 arg2 arg3
 
-readonly _gotopt_binary="${1}"
+readonly _gotopt2_binary="${1}"
 shift
 
 # Exit quickly if the binary isn't found. This may happen if the binary location
@@ -23,7 +23,7 @@ if [ -x "$(command -v ${_gotopt2_binary})" ]; then
   exit 240
 fi
 
-GOTOPT2_OUTPUT=$($_gotopt_binary "${@}" <<EOF
+GOTOPT2_OUTPUT=$($_gotopt2_binary "${@}" <<EOF
 flags:
 - name: "container"
   type: string

--- a/build/docker_run.sh.tpl
+++ b/build/docker_run.sh.tpl
@@ -12,8 +12,6 @@
 #                    --container=some-container:tag \
 #                        command arg1 arg2 arg3
 
-set -eo pipefail
-
 # This magic was copied from runfiles by consulting:
 #   https://stackoverflow.com/questions/53472993/how-do-i-make-a-bazel-sh-binary-target-depend-on-other-binary-targets
 

--- a/build/docker_run.sh.tpl
+++ b/build/docker_run.sh.tpl
@@ -1,5 +1,4 @@
 #! /bin/bash
-
 # Copyright (C) 2020 Google Inc.
 #
 # This file has been licensed under Apache 2.0 license.  Please see the LICENSE
@@ -13,12 +12,46 @@
 #                    --container=some-container:tag \
 #                        command arg1 arg2 arg3
 
-readonly _gotopt2_binary="${1}"
-shift
+set -eo pipefail
+
+# This magic was copied from runfiles by consulting:
+#   https://stackoverflow.com/questions/53472993/how-do-i-make-a-bazel-sh-binary-target-depend-on-other-binary-targets
+
+# --- begin runfiles.bash initialization ---
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+# This is somewhat of a hack: we're trying to find the runfiles path of a binary
+# whose location is with respect to its position in the dependency repo. So,
+# strip 'external/' where it applies.
+_binary_path="::GOTOPT2_BINARY::"
+if [[ "${_binary_path}" == "external/"* ]]; then
+    _binary_path="${_binary_path#external/}"
+fi
+readonly _gotopt2_binary="$(rlocation ${_binary_path})"
+
 
 # Exit quickly if the binary isn't found. This may happen if the binary location
 # moves internally in bazel.
-if [ -x "$(command -v ${_gotopt2_binary})" ]; then
+if [[ ! -x "${_gotopt2_binary}" ]]; then
   echo "gotopt2 binary not found"
   exit 240
 fi


### PR DESCRIPTION
Added a way to fix the location of the `gotopt2` binary when used from nested scripts.