### PR TITLE
fix: adds an extension to add gotopt2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "bazel_rules_bid",
-    version = "0.2.3",
+    version = "0.2.5",
 )
 
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,11 @@
 module(
     name = "bazel_rules_bid",
-    version = "0.2.1",
+    version = "0.2.2",
 )
 
-bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
+bazel_dep(
+    name = "rules_go", version = "0.50.1",
+    repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.42.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
 bazel_dep(name = "bazel_bats", version = "0.35.0")
@@ -41,4 +43,3 @@ filegroup(
 )
 """
 )
-

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "bazel_rules_bid",
-    version = "0.2.2",
+    version = "0.2.3",
 )
 
 bazel_dep(
@@ -28,18 +28,6 @@ use_repo(
     "in_gopkg_yaml_v3",
 )
 
-http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "gotopt2",
-    integrity = "sha256-qFQjgqh4fnHet1UkV38bExd64Yk582iBUi9OrClJGJo=",
-    urls = [
-        "https://github.com/filmil/gotopt2/releases/download/v1.3.1/gotopt2-linux-amd64.zip",
-    ],
-    strip_prefix = "gotopt2",
-    build_file_content = """package(default_visibility = ["//visibility:public"])
-filegroup(
-    name = "bin",
-    srcs = [ "gotopt2", ],
-)
-"""
-)
+bazel_rules_bid_extension = use_extension(
+    "@bazel_rules_bid//:extensions.bzl", "bazel_rules_bid_extension")
+use_repo(bazel_rules_bid_extension, "gotopt2")

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,0 +1,25 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def _bazel_rules_bid_extension_impl(_ctx):
+    maybe(
+        http_archive,
+        name = "gotopt2",
+        integrity = "sha256-qFQjgqh4fnHet1UkV38bExd64Yk582iBUi9OrClJGJo=",
+        urls = [
+            "https://github.com/filmil/gotopt2/releases/download/v1.3.1/gotopt2-linux-amd64.zip",
+        ],
+        strip_prefix = "gotopt2",
+        build_file_content = """package(default_visibility = ["//visibility:public"])
+    filegroup(
+        name = "bin",
+        srcs = [ "gotopt2", ],
+    )
+    """
+    )
+
+
+bazel_rules_bid_extension = module_extension(
+    implementation = _bazel_rules_bid_extension_impl,
+)

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,10 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def _bazel_rules_bid_extension_impl(_ctx):
-    maybe(
-        http_archive,
+
+    http_archive(
         name = "gotopt2",
         integrity = "sha256-qFQjgqh4fnHet1UkV38bExd64Yk582iBUi9OrClJGJo=",
         urls = [

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -12,11 +12,11 @@ def _bazel_rules_bid_extension_impl(_ctx):
         ],
         strip_prefix = "gotopt2",
         build_file_content = """package(default_visibility = ["//visibility:public"])
-    filegroup(
-        name = "bin",
-        srcs = [ "gotopt2", ],
-    )
-    """
+filegroup(
+    name = "bin",
+    srcs = [ "gotopt2", ],
+)
+"""
     )
 
 


### PR DESCRIPTION
Since gotopt2 is not a bazel registry concept, it has to be served
through an extension.