### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,8 +4,8 @@ module(
     bazel_compatibility = [">=8.0.0"],
 )
 
-bazel_dep(name = "rules_android", version = "0.7.2")
-bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "rules_android", version = "0.7.3")
+bazel_dep(name = "rules_cc", version = "0.2.19")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 bazel_dep(name = "bazel_lib", version = "3.3.1", dev_dependency = True)
@@ -15,13 +15,13 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
-bazel_dep(name = "fshlib", version = "0.2.6")
+bazel_dep(name = "fshlib", version = "0.2.0")
 bazel_dep(name = "gotopt2", version = "2.7.1")
-bazel_dep(name = "gazelle", version = "0.51.0")
+bazel_dep(name = "gazelle", version = "0.51.3")
 
-bazel_dep(name = "protobuf", version = "35.0", dev_dependency = True)
+bazel_dep(name = "protobuf", version = "35.1", dev_dependency = True)
 
-bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "rules_go", version = "0.61.1")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.12")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_android: 0.7.2 -> 0.7.3
* rules_cc: 0.2.18 -> 0.2.19
* fshlib: 0.2.6 -> 0.2.0
* gazelle: 0.51.0 -> 0.51.3
* protobuf: 35.0 -> 35.1
* rules_go: 0.60.0 -> 0.61.1