### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
-bazel_dep(name = "fshlib", version = "0.2.0")
+bazel_dep(name = "fshlib", version = "0.2.7")
 bazel_dep(name = "gotopt2", version = "2.7.1")
 bazel_dep(name = "gazelle", version = "0.51.3")
 


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* fshlib: 0.2.0 -> 0.2.7