### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "rules_android", version = "0.7.3")
-bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_cc", version = "0.2.20")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 bazel_dep(name = "bazel_lib", version = "3.3.1", dev_dependency = True)


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_cc: 0.2.19 -> 0.2.20
* fshlib: 0.2.0 -> 0.2.7
* gotopt2: 2.7.1 -> 2.8.3